### PR TITLE
Try/Catches, filename fixes

### DIFF
--- a/BeatSaviorData/FileManager.cs
+++ b/BeatSaviorData/FileManager.cs
@@ -6,112 +6,171 @@ using System.Threading.Tasks;
 using System.IO;
 using BeatSaviorData.Trackers;
 using Newtonsoft.Json;
+using System.Globalization;
 
 namespace BeatSaviorData
 {
-	class FileManager
-	{
-		private static bool isANewFile = false;
-		private static string fixedFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Beat Savior Data\\"), filePath = "";
-		private static string PBScoreGraphFileName = "_PBScoreGraphs.bsd";
+    class FileManager
+    {
+        private const int MaxStatsFiles = 30;
+        private const string FileDateFormat = "yyyy-MM-dd";
+        private const string OldFileDateFormat = "dd-MM-yyyy";
+        private static bool isANewFile = false;
+        private static string fixedFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\Beat Savior Data\\"), filePath = "";
+        private static string PBScoreGraphFileName = "_PBScoreGraphs.bsd";
 
-		private static List<ScoreGraphHolder> PBScoreGraphs;
+        private static List<ScoreGraphHolder> PBScoreGraphs;
 
-		private static void FindOrCreateFile()
-		{
-			if (!Directory.Exists(fixedFilePath))
-			{
-				Logger.log.Info("BSD : AppData directory created.");
-				Directory.CreateDirectory(fixedFilePath);
-			}
+        private static void FindOrCreateFile()
+        {
+            try
+            {
+                if (!Directory.Exists(fixedFilePath))
+                {
+                    Logger.log.Info("BSD : AppData directory created.");
+                    Directory.CreateDirectory(fixedFilePath);
+                }
 
-			filePath = fixedFilePath + DateTime.Today.ToString("dd-MM-yyyy") + ".bsd";
-			if(!File.Exists(filePath))
-			{
-				Logger.log.Info("BSD : New file \"" + Path.GetFileName(filePath) + "\" created successfully.");
-				File.Create(filePath).Dispose();
-				isANewFile = true;
-			}
+                filePath = fixedFilePath + DateTime.Today.ToString(FileDateFormat) + ".bsd";
+                if (!File.Exists(filePath))
+                {
+                    File.Create(filePath).Dispose();
+                    isANewFile = true;
+                    Logger.log.Info("BSD : New file \"" + Path.GetFileName(filePath) + "\" created successfully.");
+                }
 
-			DeleteOldRecords();
-		}
+                DeleteOldRecords();
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"BSD : Error getting data files: {ex.Message}");
+                Logger.log.Debug(ex);
+            }
+        }
 
-		private static void DeleteOldRecords()
-		{
-			string[] files = Directory.GetFiles(fixedFilePath);
-			SortedDictionary<DateTime, string> filesWithTime = new SortedDictionary<DateTime, string>();
+        private static void DeleteOldRecords()
+        {
+            string[] files = Directory.GetFiles(fixedFilePath);
+            SortedDictionary<DateTime, string> filesWithTime = new SortedDictionary<DateTime, string>();
 
-			foreach(string s in files)
-			{
-				if (Path.GetFileNameWithoutExtension(s).StartsWith("_"))
-					continue;
+            foreach (string s in files)
+            {
+                string fileName = Path.GetFileNameWithoutExtension(s);
+                if (fileName.StartsWith("_"))
+                    continue;
+                if (DateTime.TryParseExact(fileName, FileDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
+                {
+                    //Logger.log.Debug($"Loaded '{fileName}' -> {date.ToString("d")}");
+                    filesWithTime.Add(date, s);
+                }
+                else if (DateTime.TryParseExact(fileName, OldFileDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out  date))
+                {
+                    //Logger.log.Debug($"Loaded old format '{fileName}' -> {date.ToString("d")}");
+                    filesWithTime.Add(date, s);
+                }
+                else
+                    Logger.log.Debug($"Unexpected file: '{fileName}' ({s}) in Beat Savior Data folder.");
+            }
 
-				filesWithTime.Add(DateTime.Parse(Path.GetFileNameWithoutExtension(s)), s);
-			}
+            while (filesWithTime.Count > MaxStatsFiles)
+            {
+                KeyValuePair<DateTime, string> entry = filesWithTime.First();
+                try
+                {
+                    File.Delete(entry.Value);
+                    filesWithTime.Remove(entry.Key);
+                    Logger.log.Info("BSD : Oldest file \"" + Path.GetFileName(entry.Value) + "\" deleted.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.log.Error($"BSD : Error deleting old stats file '{Path.GetFileName(entry.Value)}': {ex.Message}");
+                    Logger.log.Debug(ex);
+                }
+            }
+        }
 
-			while(filesWithTime.Count > 30)
-			{
-				Logger.log.Info("BSD : Oldest file \"" + Path.GetFileName(filesWithTime.First().Value) + "\" deleted.");
-				File.Delete(filesWithTime.First().Value);
-				filesWithTime.Remove(filesWithTime.First().Key);
-			}
-		}
+        public static void SavePlayerStats(string json)
+        {
+            try
+            {
 
-		public static void SavePlayerStats(string json)
-		{
-			FindOrCreateFile();
+                FindOrCreateFile();
 
-			if (!isANewFile)
-			{
-				Logger.log.Info("BSD : File already exists, player stats ignored.");
-				return;
-			}
+                if (!isANewFile)
+                {
+                    Logger.log.Info("BSD : File already exists, player stats ignored.");
+                    return;
+                }
 
-			File.AppendAllText(filePath, json);
-			Logger.log.Info("BSD : Player stats saved successfully.");
-		}
+                File.AppendAllText(filePath, json);
+                Logger.log.Info("BSD : Player stats saved successfully.");
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"BSD : Error saving player stats: {ex.Message}");
+                Logger.log.Debug(ex);
+            }
+        }
 
-		public static void SaveSongStats(string json)
-		{
-			File.AppendAllText(filePath, "\n" + json);
-			Logger.log.Info("BSD : Song stats saved successfully.");
-		}
+        public static void SaveSongStats(string json)
+        {
+            try
+            {
+                File.AppendAllText(filePath, "\n" + json);
+                Logger.log.Info("BSD : Song stats saved successfully.");
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"BSD : Error saving song stats: {ex.Message}");
+                Logger.log.Debug(ex);
+            }
+        }
 
-		public static void SavePBScoreGraph(Dictionary<float, float> graph, int score, string songHash)
-		{
-			string filePath = fixedFilePath + PBScoreGraphFileName;
-			ScoreGraphHolder tmpGraph;
+        public static void SavePBScoreGraph(Dictionary<float, float> graph, int score, string songHash)
+        {
+            try
+            {
+                string filePath = fixedFilePath + PBScoreGraphFileName;
+                ScoreGraphHolder tmpGraph;
 
-			// FindOrCreateFile has been executed first, so the file path exists.
-			if (!File.Exists(filePath)) {
-				File.Create(filePath).Dispose();
-				PBScoreGraphs = new List<ScoreGraphHolder>();
-			} else if (PBScoreGraphs == null)
-				PBScoreGraphs = JsonConvert.DeserializeObject<List<ScoreGraphHolder>>(File.ReadAllText(filePath));
+                // FindOrCreateFile has been executed first, so the file path exists.
+                if (!File.Exists(filePath))
+                {
+                    File.Create(filePath).Dispose();
+                    PBScoreGraphs = new List<ScoreGraphHolder>();
+                }
+                else if (PBScoreGraphs == null)
+                    PBScoreGraphs = JsonConvert.DeserializeObject<List<ScoreGraphHolder>>(File.ReadAllText(filePath));
 
-			tmpGraph = PBScoreGraphs.Find((g) => g.songHash == songHash);
+                tmpGraph = PBScoreGraphs.Find((g) => g.songHash == songHash);
 
-			if(tmpGraph == null || tmpGraph.score < score)
-			{
-				if (tmpGraph != null)
-					PBScoreGraphs.Remove(tmpGraph);
-				PBScoreGraphs.Add(new ScoreGraphHolder(graph, score, songHash));
-				File.WriteAllText(filePath, JsonConvert.SerializeObject(PBScoreGraphs));
-			}
-		}
+                if (tmpGraph == null || tmpGraph.score < score)
+                {
+                    if (tmpGraph != null)
+                        PBScoreGraphs.Remove(tmpGraph);
+                    PBScoreGraphs.Add(new ScoreGraphHolder(graph, score, songHash));
+                    File.WriteAllText(filePath, JsonConvert.SerializeObject(PBScoreGraphs));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.log.Error($"BSD : Error saving score graph: {ex.Message}");
+                Logger.log.Debug(ex);
+            }
+        }
 
-		private class ScoreGraphHolder
-		{
-			public string songHash;
-			public int score;
-			public Dictionary<float, float> graph;
+        private class ScoreGraphHolder
+        {
+            public string songHash;
+            public int score;
+            public Dictionary<float, float> graph;
 
-			public ScoreGraphHolder(Dictionary<float, float> graph, int score, string songHash)
-			{
-				this.songHash = songHash;
-				this.score = score;
-				this.graph = graph;
-			}
-		}
-	}
+            public ScoreGraphHolder(Dictionary<float, float> graph, int score, string songHash)
+            {
+                this.songHash = songHash;
+                this.score = score;
+                this.graph = graph;
+            }
+        }
+    }
 }

--- a/BeatSaviorData/HTTPManager.cs
+++ b/BeatSaviorData/HTTPManager.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,14 +12,34 @@ namespace BeatSaviorData
 
 		public async static void UploadPlayerStats(string json)
 		{
-			if(!SettingsMenu.instance.DisableBeatSaviorUpload)
-				await Upload(json, PrivateKeys.BeatSaviorPlayerDataUploadURL);
+			if (!SettingsMenu.instance.DisableBeatSaviorUpload)
+			{
+                try
+                {
+                    await Upload(json, PrivateKeys.BeatSaviorPlayerDataUploadURL);
+				}
+				catch (Exception ex)
+				{
+					Logger.log.Error($"BSD : Error uploading player stats to BeatSavior");
+					Logger.log.Debug(ex);
+				}
+			}
 		}
 
 		public async static void UploadSongJson(string json)
 		{
 			if (!SettingsMenu.instance.DisableBeatSaviorUpload)
-				await Upload(json, PrivateKeys.BeatSaviorSongUploadUrl);
+			{
+                try
+                {
+                    await Upload(json, PrivateKeys.BeatSaviorSongUploadUrl);
+				}
+				catch (Exception ex)
+				{
+					Logger.log.Error($"BSD : Error uploading song results to BeatSavior");
+					Logger.log.Debug(ex);
+				}
+			}
 		}
 
 		private async static Task Upload(string json, string url)

--- a/BeatSaviorData/Plugin.cs
+++ b/BeatSaviorData/Plugin.cs
@@ -50,6 +50,8 @@ namespace BeatSaviorData
 
 		private void DiscardSongData(StandardLevelScenesTransitionSetupDataSO data, LevelCompletionResults results)
 		{
+			if (songData == null)
+				return;
 			songData.GetDataCollector().UnregisterCollector(songData);
 			songData = null;
 		}


### PR DESCRIPTION
* The previous filename date format (`dd-MM-yyyy`) was getting parsed incorrectly (day and month were switched around). This was causing an exception when the day was higher than 12.
   * Switched the date format for new files to `yyyy-MM-dd` and used `DateTime.TryParseExact` for parsing.
   * If parsing for the new format fails, it tries again with the old format, which should now be read correctly.
* Wrapped all the file IO and HTTP posts in Try/Catch blocks for safety, we don't want to throw exceptions in harmony patches or external events.
* Fixes #5 