### PR TITLE
Fix BSD breaking after playing multiplayer

### DIFF
--- a/BeatSaviorData/Plugin.cs
+++ b/BeatSaviorData/Plugin.cs
@@ -156,6 +156,9 @@ namespace BeatSaviorData
 		{
 			if (nextScene.name == "GameCore")
 			{
+                if (BS_Utils.Plugin.LevelData.Mode == BS_Utils.Gameplay.Mode.Multiplayer)
+					return;
+                    
 				GameSceneLoaded();
 
 				foreach(MissionLevelScenesTransitionSetupDataSO m in Resources.FindObjectsOfTypeAll<MissionLevelScenesTransitionSetupDataSO>())

--- a/BeatSaviorData/Plugin.cs
+++ b/BeatSaviorData/Plugin.cs
@@ -156,7 +156,7 @@ namespace BeatSaviorData
 		{
 			if (nextScene.name == "GameCore")
 			{
-                if (BS_Utils.Plugin.LevelData.Mode == BS_Utils.Gameplay.Mode.Multiplayer)
+				if (BS_Utils.Plugin.LevelData.Mode == BS_Utils.Gameplay.Mode.Multiplayer)
 					return;
                     
 				GameSceneLoaded();

--- a/BeatSaviorData/Stats/SongData.cs
+++ b/BeatSaviorData/Stats/SongData.cs
@@ -60,7 +60,7 @@ namespace BeatSaviorData
 		public SongData()
 		{
 			if (!BS_Utils.Plugin.LevelData.IsSet)
-            {
+			{
 				Logger.log.Error("BS_Utils level data is not present. Did you start the tutorial ?");
 				return;
 			}

--- a/BeatSaviorData/Stats/SongData.cs
+++ b/BeatSaviorData/Stats/SongData.cs
@@ -1,4 +1,5 @@
 ﻿using BS_Utils.Gameplay;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -60,11 +61,14 @@ namespace BeatSaviorData
 		{
 			try
 			{
-				BOSC = Resources.FindObjectsOfTypeAll<BeatmapObjectSpawnController>().First();
+				BOSC = Resources.FindObjectsOfTypeAll<BeatmapObjectSpawnController>().Last();						// Does this get used for anything?
 				GCSSD = BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData;
 				modifierData = Resources.FindObjectsOfTypeAll<GameplayModifiersModelSO>().First();
 				playerData = Resources.FindObjectsOfTypeAll<PlayerDataModel>().First();
-				scoreController = Resources.FindObjectsOfTypeAll<ScoreController>().First();
+
+				// Ideally, this would get used with (x => x.isActiveAndEnabled). However, when SongData is getting created, no ScoreController is active and enabled at that point in time.
+				// Getting the last one might be good enough, though.
+				scoreController = Resources.FindObjectsOfTypeAll<ScoreController>().Last();		
 			} catch (Exception)
 			{
 				Logger.log.Error("SongData couldn't be created. Did you start the tutorial ?");
@@ -105,7 +109,8 @@ namespace BeatSaviorData
 			await Task.Delay(500);
 
 			try {
-				songDuration = Resources.FindObjectsOfTypeAll<AudioTimeSyncController>().FirstOrDefault().songLength;
+				AudioTimeSyncController audioTimeSyncController = Resources.FindObjectsOfTypeAll<AudioTimeSyncController>().LastOrDefault(x => x.isActiveAndEnabled);
+				songDuration = audioTimeSyncController.songLength;
 			} catch {
 				Logger.log.Error("BSD : Could not get song length !");
 				songDuration = -1;

--- a/BeatSaviorData/Stats/SongData.cs
+++ b/BeatSaviorData/Stats/SongData.cs
@@ -59,6 +59,12 @@ namespace BeatSaviorData
 
 		public SongData()
 		{
+			if (!BS_Utils.Plugin.LevelData.IsSet)
+            {
+				Logger.log.Error("BS_Utils level data is not present. Did you start the tutorial ?");
+				return;
+			}
+				
 			try
 			{
 				BOSC = Resources.FindObjectsOfTypeAll<BeatmapObjectSpawnController>().Last();						// Does this get used for anything?


### PR DESCRIPTION
This PR disables BSD data collection in multiplayer mode and changes some things in order to handle lingering base game objects from multiplayer when going back to solo mode.

Works for me (TM), but there might be some additional places that could need adjustments. I'm not familiar enough with the code base to evaluate that.