### PR TITLE
Fix for 1.17.0

### DIFF
--- a/BeatSaviorData/Properties/AssemblyInfo.cs
+++ b/BeatSaviorData/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.7")]
-[assembly: AssemblyFileVersion("2.1.7")]
+[assembly: AssemblyVersion("2.1.8")]
+[assembly: AssemblyFileVersion("2.1.8")]

--- a/BeatSaviorData/Stats/Trackers/ScoreTracker.cs
+++ b/BeatSaviorData/Stats/Trackers/ScoreTracker.cs
@@ -30,7 +30,7 @@ namespace BeatSaviorData.Trackers
 		{
 			IDifficultyBeatmap beatmap = data.GetGCSSD().difficultyBeatmap;
 			PlayerLevelStatsData stats = data.GetPlayerData().playerData.GetPlayerLevelStatsData(beatmap.level.levelID, beatmap.difficulty, beatmap.parentDifficultyBeatmapSet.beatmapCharacteristic);
-			maxRawScore = ScoreModel.MaxRawScoreForNumberOfNotes(beatmap.beatmapData.cuttableNotesType);
+			maxRawScore = ScoreModel.MaxRawScoreForNumberOfNotes(beatmap.beatmapData.cuttableNotesCount);
 
 			modifiersMultiplier = GetTotalMultiplier(data.GetPlayerData().playerData.gameplayModifiers, results.energy);
 			maxScore = Mathf.RoundToInt(maxRawScore * modifiersMultiplier);

--- a/BeatSaviorData/manifest.json
+++ b/BeatSaviorData/manifest.json
@@ -3,13 +3,13 @@
   "id": "BeatSaviorData",
   "name": "BeatSaviorData",
   "author": "Mystogan",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Show in-depth stats and a score graph at the end of songs, also uploads those stats to Beat Savior, and save in-depth stats localy to be used by BeatSaviorAnalyzer",
-  "gameVersion": "1.16.2",
+  "gameVersion": "1.17.0",
   "dependsOn": {
     "BSIPA": "^4.1.6",
-    "BS Utils": "^1.10.0",
-    "BeatSaberMarkupLanguage": "^1.5.3"
+    "BS Utils": "^1.11.0",
+    "BeatSaberMarkupLanguage": "^1.5.5"
   },
   "loadAfter": [ "BS Utils", "BeatSaberMarkupLanguage" ],
   "misc": {


### PR DESCRIPTION
As title. The game developers change the field `BeatmapData.cuttableNotesType` to `BeatmapData.cuttableNotesCount` in 1.17.0. I think this is the only place where it breaks. Other than this change, I just bumped the versions.

Since I don't think I can get `PrivateKeys.cs` file, I can't build the mod from source. In order to test the changes, I edited the dll in dnSpy and recompiled it. It is working as far as I can tell.
