### PR TITLE
Fix badcut and combo

### DIFF
--- a/BeatSaviorData/Stats/DataCollector.cs
+++ b/BeatSaviorData/Stats/DataCollector.cs
@@ -24,6 +24,7 @@ namespace BeatSaviorData
 			phaoi = phaoi ?? sc.GetField<PlayerHeadAndObstacleInteraction, ScoreController>("_playerHeadAndObstacleInteraction");
 
 			sc.scoringForNoteStartedEvent += OnNoteCut;
+			bom.noteWasCutEvent += OnMaybeBadCut;
 			bom.noteWasMissedEvent += OnNoteMiss;
 			phaoi.headDidEnterObstaclesEvent += BreakComboByWalls;
 			BS_Utils.Utilities.BSEvents.songPaused += SongPaused;
@@ -35,6 +36,7 @@ namespace BeatSaviorData
 				maxCombo = combo;
 
 			sc.scoringForNoteStartedEvent -= OnNoteCut;
+			bom.noteWasCutEvent -= OnMaybeBadCut;
 			bom.noteWasMissedEvent -= OnNoteMiss;
 			phaoi.headDidEnterObstaclesEvent -= BreakComboByWalls;
 			BS_Utils.Utilities.BSEvents.songPaused -= SongPaused;
@@ -53,28 +55,14 @@ namespace BeatSaviorData
 					ComputeMultiplier(true);
 					notes.Add(new Note(goodCut, CutType.cut, info, multiplier));
 				}
-				else if (goodCut.noteData.colorType != ColorType.None)
-				{
-					ComputeMultiplier(false);
-					notes.Add(new Note(goodCut, CutType.badCut, info, multiplier));
-				}
-				else if (goodCut.noteData.colorType == ColorType.None)
-				{
-					ComputeMultiplier(false);
-					bombHit++;
-				}
 			}
 		}
 
-		/*private void OnNoteCut(NoteController controller, in NoteCutInfo info)
+		private void OnMaybeBadCut(NoteController controller, in NoteCutInfo info)
 		{
 			// (data.colorType != ColorType.None) checks if it is not a bomb
 			if (info.allIsOK && controller.noteData.colorType != ColorType.None)
-			{
-				combo++;
-				ComputeMultiplier(true);
-				notes.Add(new Note(controller, CutType.cut, info, multiplier));
-			}
+			{ }
 			else if (controller.noteData.colorType != ColorType.None)
 			{
 				ComputeMultiplier(false);
@@ -85,7 +73,7 @@ namespace BeatSaviorData
 				ComputeMultiplier(false);
 				bombHit++;
 			}
-		}*/
+		}
 
 		private void OnNoteMiss(NoteController controller)
 		{
@@ -100,6 +88,9 @@ namespace BeatSaviorData
 		{
 			if(!goodHit)
 			{
+				if (combo > maxCombo)
+					maxCombo = combo;
+				combo = 0;
 				if(multiplier > 1)
 					multiplier /= 2;
 				multiplierProgress = 0;
@@ -119,10 +110,6 @@ namespace BeatSaviorData
 			// We only reset multiplier on walls hit because we already count miss, badcuts and bombs in other events
 			ComputeMultiplier(false);
 			nbOfWallHit++;
-
-			if (combo > maxCombo)
-				maxCombo = combo;
-			combo = 0;
 		}
 
 		private void SongPaused()

--- a/BeatSaviorData/Stats/Note.cs
+++ b/BeatSaviorData/Stats/Note.cs
@@ -97,6 +97,14 @@ namespace BeatSaviorData
 
 			distanceToCenter = info.cutDistanceToCenter;
 		}
+		
+		// Bad Cut
+		public Note(NoteController controller, CutType cut, NoteCutInfo _info, int _multiplier) : this(controller, cut)
+		{
+			multiplier = _multiplier;
+
+			info = _info;
+		}
 
 		public Note(NoteController controller, CutType cut, int _multiplier) : this(controller, cut)
 		{


### PR DESCRIPTION
Bad cuts haven't been counted for a while, since 1.21.0 probably? Somewhat revived the old OnNoteCut because BadCutScoringElement didn't seem to have all the necessary position/rotation info.

Also moved the combo handling into ComputeMultiplier because only wall hits were breaking combo.