### PR TITLE
Changes for Beat Saber 1.37.1

### DIFF
--- a/BeatSaviorData/BeatSaviorData.csproj
+++ b/BeatSaviorData/BeatSaviorData.csproj
@@ -1,144 +1,148 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
-        <OutputType>Library</OutputType>
-        <LangVersion>8</LangVersion>
-        <Nullable>disable</Nullable>
-        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-        <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
-        <BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
-        <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
-        <DebugType>portable</DebugType>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
-        <DisableCopyToPlugins>True</DisableCopyToPlugins>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(NCrunch)' == '1'">
-        <DisableCopyToPlugins>True</DisableCopyToPlugins>
-        <DisableZipRelease>True</DisableZipRelease>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Reference Include="System.Net.Http" />
-        <Reference Include="UnityEngine">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Unity.TextMeshPro">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="UnityEngine.TextRenderingModule">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="UnityEngine.UI">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="UnityEngine.UIModule">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Main">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="BeatmapCore">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="BGLib.AppFlow">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="BGLib.UnityExtension">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Colors">
-            <SpecificVersion>False</SpecificVersion>
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
-        </Reference>
-        <Reference Include="DataModels">
-            <SpecificVersion>False</SpecificVersion>
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
-        </Reference>
-        <Reference Include="GameplayCore">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="HMLib">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="HMUI">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="IPA.Loader">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="PlatformUserModel">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\PlatformUserModel.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="0Harmony">
-            <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Hive.Versioning">
-            <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Newtonsoft.Json">
-            <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="BSML">
-            <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="BS_Utils">
-            <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
-            <Private>False</Private>
-        </Reference>
-        <Reference Include="Zenject">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="Zenject-usage">
-            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-        <Reference Include="SiraUtil">
-            <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
-        <None Include="BeatSaviorData.csproj.user" Condition="Exists('BeatSaviorData.csproj.user')" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <EmbeddedResource Include="manifest.json" />
-        <EmbeddedResource Include="UI\Views\*.bsml" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="BeatSaberModdingTools.Tasks" Version="2.0.0-beta4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Library</OutputType>
+    <LangVersion>8</LangVersion>
+    <Nullable>disable</Nullable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <LocalRefsDir Condition="Exists('..\Refs')">..\Refs</LocalRefsDir>
+    <BeatSaberDir>$(LocalRefsDir)</BeatSaberDir>
+    <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(DefineConstants.Contains('CIBuild')) OR '$(NCrunch)' == '1'">
+    <DisableCopyToPlugins>True</DisableCopyToPlugins>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(NCrunch)' == '1'">
+    <DisableCopyToPlugins>True</DisableCopyToPlugins>
+    <DisableZipRelease>True</DisableZipRelease>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Reference Include="BeatSaber.ViewSystem">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="UnityEngine">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Unity.TextMeshPro">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Main">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BeatmapCore">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BGLib.AppFlow">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BGLib.UnityExtension">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Colors">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
+    </Reference>
+    <Reference Include="DataModels">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+    </Reference>
+    <Reference Include="GameplayCore">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="HMLib">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="HMUI">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="IPA.Loader">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="PlatformUserModel">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\PlatformUserModel.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Hive.Versioning">
+      <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BSML">
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="BS_Utils">
+      <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Zenject">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Zenject-usage">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="SiraUtil">
+      <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
+    <None Include="BeatSaviorData.csproj.user" Condition="Exists('BeatSaviorData.csproj.user')" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="manifest.json" />
+    <EmbeddedResource Include="UI\Views\*.bsml" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="BeatSaberModdingTools.Tasks" Version="2.0.0-beta4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/BeatSaviorData/BeatSaviorData.csproj
+++ b/BeatSaviorData/BeatSaviorData.csproj
@@ -55,9 +55,21 @@
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll</HintPath>
             <Private>False</Private>
         </Reference>
+        <Reference Include="BGLib.AppFlow">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="BGLib.UnityExtension">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.UnityExtension.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="Colors">
             <SpecificVersion>False</SpecificVersion>
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
+        </Reference>
+        <Reference Include="DataModels">
+            <SpecificVersion>False</SpecificVersion>
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
         </Reference>
         <Reference Include="GameplayCore">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
@@ -73,6 +85,10 @@
         </Reference>
         <Reference Include="IPA.Loader">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="PlatformUserModel">
+            <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\PlatformUserModel.dll</HintPath>
             <Private>False</Private>
         </Reference>
         <Reference Include="0Harmony">

--- a/BeatSaviorData/Plugin.cs
+++ b/BeatSaviorData/Plugin.cs
@@ -10,6 +10,7 @@ using BeatSaviorData.Trackers;
 using System.Security.Cryptography.X509Certificates;
 using System.Net;
 using System.Net.Security;
+using BeatSaberMarkupLanguage.Util;
 
 namespace BeatSaviorData
 {
@@ -43,10 +44,10 @@ namespace BeatSaviorData
 			BSEvents.levelFailed += UploadSoloData;
 			BSEvents.lateMenuSceneLoadedFresh += UploadStats;
 
+			BSEvents.earlyMenuSceneLoadedFresh += AddSettingsMenuOnMenuLoad;
+
 			BSEvents.levelQuit += DiscardSongData;
 			BSEvents.levelRestarted += DiscardSongData;
-
-			BSMLSettings.instance.AddSettingsMenu("BeatSaviorData", "BeatSaviorData.UI.Views.SettingsView.bsml", SettingsMenu.instance);
 
 			harmony = new Harmony("BeatSaviorData");
 
@@ -57,7 +58,12 @@ namespace BeatSaviorData
 			new GameObject("EndOfLevelUICreator").AddComponent<EndOfLevelUICreator>().plugin = this;
 		}
 
-		private void UploadStats(ScenesTransitionSetupDataSO obj)
+        private void AddSettingsMenuOnMenuLoad(ScenesTransitionSetupDataSO sO)
+        {
+            BSMLSettings.Instance.AddSettingsMenu("BeatSaviorData", "BeatSaviorData.UI.Views.SettingsView.bsml", SettingsMenu.instance);
+        }
+
+        private void UploadStats(ScenesTransitionSetupDataSO obj)
 		{ 
 			new PlayerStats();	// Get and upload player related stats
 			BSEvents.lateMenuSceneLoadedFresh -= UploadStats;
@@ -113,7 +119,9 @@ namespace BeatSaviorData
 			BSEvents.levelCleared -= UploadSoloData;
 			BSEvents.levelFailed -= UploadSoloData;
 			BSEvents.lateMenuSceneLoadedFresh -= UploadStats;
-		}
+
+            BSEvents.earlyMenuSceneLoadedFresh -= AddSettingsMenuOnMenuLoad;
+        }
 
 		private void UploadData(StandardLevelScenesTransitionSetupDataSO data, LevelCompletionResults results, bool isCampaign)
 		{

--- a/BeatSaviorData/SettingsMenu.cs
+++ b/BeatSaviorData/SettingsMenu.cs
@@ -1,4 +1,5 @@
 ﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Util;
 using BS_Utils.Utilities;
 
 namespace BeatSaviorData

--- a/BeatSaviorData/Stats/SongData.cs
+++ b/BeatSaviorData/Stats/SongData.cs
@@ -80,7 +80,7 @@ namespace BeatSaviorData
 				BOSC = Resources.FindObjectsOfTypeAll<BeatmapObjectSpawnController>().Last();
 				modifierData = Resources.FindObjectsOfTypeAll<GameplayModifiersModelSO>().First();
 				playerData = Resources.FindObjectsOfTypeAll<PlayerDataModel>().First();
-				beatmapData = GCSSD.beatmapDataCache.GetBeatmapData(GCSSD.difficultyBeatmap, GCSSD.environmentInfo, GCSSD.playerSpecificSettings).Result;
+				beatmapData = GCSSD.transformedBeatmapData;
 
 				BOSC.didInitEvent += BOSCDidInit;
 
@@ -100,14 +100,14 @@ namespace BeatSaviorData
 			else
 				UserIDFix.UserIDReady += SetUserID;
 
-			songID = GCSSD.difficultyBeatmap.level.levelID.Replace("custom_level_","").Split('_')[0];
-			songDifficulty = GCSSD.difficultyBeatmap.difficulty.ToString().ToLower();
-			gameMode = GCSSD.difficultyBeatmap.parentDifficultyBeatmapSet.beatmapCharacteristic.serializedName;
+			songID = GCSSD.beatmapKey.levelId.Replace("custom_level_","").Split('_')[0];
+			songDifficulty = GCSSD.beatmapKey.difficulty.ToString().ToLower();
+			gameMode = GCSSD.beatmapKey.beatmapCharacteristic.serializedName;
 
-			songDifficultyRank = GCSSD.difficultyBeatmap.difficultyRank;
-			songName = GCSSD.difficultyBeatmap.level.songName;
-			songArtist = GCSSD.difficultyBeatmap.level.songAuthorName;
-			songMapper = GCSSD.difficultyBeatmap.level.levelAuthorName;
+			songDifficultyRank = GCSSD.beatmapKey.beatmapCharacteristic.sortingOrder;
+			songName = GCSSD.beatmapLevel.songName;
+			songArtist = GCSSD.beatmapLevel.songAuthorName;
+			songMapper = GCSSD.beatmapLevel.allMappers.FirstOrDefault() ?? string.Empty;
 
 			WaitForAudioTimeSyncController();
 

--- a/BeatSaviorData/Stats/Trackers/ScoreTracker.cs
+++ b/BeatSaviorData/Stats/Trackers/ScoreTracker.cs
@@ -28,8 +28,8 @@ namespace BeatSaviorData.Trackers
 
 		public void GetMaxScores(LevelCompletionResults results, SongData data)
 		{
-			IDifficultyBeatmap beatmap = data.GetGCSSD().difficultyBeatmap;
-			PlayerLevelStatsData stats = data.GetPlayerData().playerData.GetPlayerLevelStatsData(beatmap.level.levelID, beatmap.difficulty, beatmap.parentDifficultyBeatmapSet.beatmapCharacteristic);
+			BeatmapKey beatmap = data.GetGCSSD().beatmapKey;
+			PlayerLevelStatsData stats = data.GetPlayerData().playerData.TryGetPlayerLevelStatsData(in beatmap);
 			maxRawScore = Utils.MaxRawScoreForNumberOfNotes(data.GetBeatmapData().cuttableNotesCount);
 
 			modifiersMultiplier = GetTotalMultiplier(data.GetPlayerData().playerData.gameplayModifiers, results.energy);

--- a/BeatSaviorData/UI/EndOfLevelUI.cs
+++ b/BeatSaviorData/UI/EndOfLevelUI.cs
@@ -292,7 +292,7 @@ namespace BeatSaviorData
 
             #region TitleCard
             // SongCover
-            Sprite s = data.GetGCSSD().difficultyBeatmap.level.GetCoverImageAsync(new System.Threading.CancellationToken()).Result;
+            Sprite s = data.GetGCSSD().beatmapLevel.previewMediaData.GetCoverSpriteAsync(new System.Threading.CancellationToken()).Result;
             songCoverImg.sprite = s;
 
             // Title
@@ -382,7 +382,7 @@ namespace BeatSaviorData
 
             #region LeftSaberStats
             // LeftCircle
-            SharedCoroutineStarter.instance.StartCoroutine(AnimateCircle(leftCircleImg, GetCircleFillRatio(at.accLeft), 1.5f));
+            StartCoroutine(AnimateCircle(leftCircleImg, GetCircleFillRatio(at.accLeft), 1.5f));
 
             // LeftAverageCut
             leftAverage.text = at.accLeft.ToString("0.##");
@@ -411,7 +411,7 @@ namespace BeatSaviorData
 
             #region RightSaberStats
             // rightCircle
-            SharedCoroutineStarter.instance.StartCoroutine(AnimateCircle(rightCircleImg, GetCircleFillRatio(at.accRight), 1.5f));
+            StartCoroutine(AnimateCircle(rightCircleImg, GetCircleFillRatio(at.accRight), 1.5f));
 
             // rightAverageCut
             rightAverage.text = at.accRight.ToString("0.##");


### PR DESCRIPTION
### Notes:
1.34.4 introduced a new beatmap model but everything needed is still there. Mappers and lighters are separate lists which currently aren't used because BeatSaver is yet to support v4 beatmaps, and these aren't parsed/displayed anywhere within the game so there's no defined way to display v4 beatmap authors. Taking the first of the list should work just fine for anything before v4.

It seems that the percentage score result calculation is sometimes off however I wasn't able to consistently reproduce. Sometimes it would show a percentage greater than 100%.